### PR TITLE
list() call around the call to map()

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -106,7 +106,7 @@ def make_submission(clf, encoder, path='my_submission.csv'):
         f.write(','.join(encoder.classes_))
         f.write('\n')
         for id, probs in zip(ids, y_prob):
-            probas = ','.join([id] + map(str, probs.tolist()))
+            probas = ','.join([id] + list(map(str, probs.tolist())))
             f.write(probas)
             f.write('\n')
     print(" -- Wrote submission to file {}.".format(path))


### PR DESCRIPTION
This small change makes code compatible with Python 3. Otherwise `','.join([id] + map(str, probs.tolist()))` produces error "_TypeError: can only concatenate list (not "map") to list_" since in Python 3 map() returns an iterator instead of a list.
